### PR TITLE
add time zone and service region attributes

### DIFF
--- a/db/migrate/20200724150114_add_time_zone_and_service_region_to_changes_and_actions.rb
+++ b/db/migrate/20200724150114_add_time_zone_and_service_region_to_changes_and_actions.rb
@@ -1,0 +1,9 @@
+class AddTimeZoneAndServiceRegionToChangesAndActions < ActiveRecord::Migration[5.2]
+  def change
+    add_column :delay_henka_scheduled_changes, :time_zone, :string
+    add_column :delay_henka_scheduled_changes, :service_region_id, :integer
+
+    add_column :delay_henka_scheduled_actions, :time_zone, :string
+    add_column :delay_henka_scheduled_actions, :service_region_id, :integer
+  end
+end

--- a/db/migrate/20200724150636_add_index_on_time_zone_to_changes_and_actions.rb
+++ b/db/migrate/20200724150636_add_index_on_time_zone_to_changes_and_actions.rb
@@ -1,0 +1,8 @@
+class AddIndexOnTimeZoneToChangesAndActions < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def change
+    add_index :delay_henka_scheduled_changes, :time_zone, algorithm: :concurrently
+    add_index :delay_henka_scheduled_actions, :time_zone, algorithm: :concurrently
+  end
+end


### PR DESCRIPTION
Adding attributes to Changes/Actions models in preparation of moving service workers to a time zone based execution schedule.
